### PR TITLE
Solution4: Serve Static Assets

### DIFF
--- a/myApp.js
+++ b/myApp.js
@@ -1,15 +1,25 @@
-let express = require('express');
-let app = express();
+let express = require('express')
+let app = express()
+const path = require('path')
 
+//Solution2: Start a Working Express Server
 // app.get("/", (req, res) => {
-//     res.send("Hello Express");
-// });
+//     res.send("Hello Express")
+// })
 
-let absolutePath = __dirname + '/views/index.html'
+//Solution3: Serve an HTML File
+// let absolutePath = __dirname + '/views/index.html'
+// app.get("/", (req, res) => {
+//     res.sendFile(absolutePath)
+// })
 
-app.get("/", (req, res) => {
-    res.sendFile(absolutePath);
-});
+//Solution4: Serve Static Assets
+app.use('/public', express.static(path.join(__dirname, 'public')))
+app.get('/', (req, res) => {
+    res.sendFile(path.join(__dirname, 'views', 'index.html'))
+})
+
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "dotenv": "^16.0.1",
         "express": "^4.14.0",
         "fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git",
-        "nodemon": "^3.1.0"
+        "nodemon": "^3.1.0",
+        "path": "^0.12.7"
       }
     },
     "node_modules/abbrev": {
@@ -755,6 +756,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -769,6 +779,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -1017,6 +1035,19 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
+    },
+    "node_modules/util/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dotenv": "^16.0.1",
     "express": "^4.14.0",
     "fcc-express-bground": "https://github.com/freeCodeCamp/fcc-express-bground-pkg.git",
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "path": "^0.12.7"
   },
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Mount the express.static() middleware to the path /public with app.use(). The absolute path to the assets folder is __dirname + /public.

Now your app should be able to serve a CSS stylesheet. Note that the /public/style.css file is referenced in the /views/index.html in the project boilerplate. Your front-page should look a little better now!